### PR TITLE
Expose received device state.

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -16,6 +16,26 @@ fn main() {
     display_response("State", &device.response);
     thread::sleep(Duration::from_millis(1000));
 
+    // Parse out HSVK details.
+    println!("\nCurrent state received:");
+    let payload = match device.response.payload {
+        response::Payload::State(ref v) => Some(v),
+        _ => None,
+    };
+
+    match payload {
+        Some(v) => {
+            println!("current payload body: {:?}", v.body);
+            println!("current hue: {:?}", v.hue);
+            println!("current sat: {:?}", v.saturation);
+            println!("current bri: {:?}", v.brightness);
+            println!("current kel: {:?}", v.kelvin);
+        },
+        None => (),
+    };
+    println!("\n");
+
+
     // Set colour.
 
     // Use constants.

--- a/src/response.rs
+++ b/src/response.rs
@@ -57,18 +57,18 @@ pub enum Payload {
 
 #[derive(Debug)]
 pub struct StateServicePayload {
-    service: String,
-    port: String,
-    unknown: String,
+    pub service: String,
+    pub port: String,
+    pub unknown: String,
 }
 
 #[derive(Debug)]
 pub struct StatePayload {
-    body: String,
-    hue: String,
-    saturation: String,
-    brightness: String,
-    kelvin: String,
+    pub body: String,
+    pub hue: String,
+    pub saturation: String,
+    pub brightness: String,
+    pub kelvin: String,
 }
 
 fn parse_payload_3(resp: &ResponseMessage) -> Payload {


### PR DESCRIPTION
This commit exposes the state properties retrieved from the device for display or other use by the client such as returning the device to its original state after change.